### PR TITLE
fix padding of input text so it's not hidden by filters

### DIFF
--- a/src/css/components/forms/input.scss
+++ b/src/css/components/forms/input.scss
@@ -9,7 +9,7 @@
   font-weight: normal;
   line-height: normal;
   color: #323232;
-  padding: 10px 11px 11px;
+  padding: 10px 56px 11px 11px;
   transition: border .2s;
 }
 .Input:active,

--- a/src/css/components/views/EventsBrowser.scss
+++ b/src/css/components/views/EventsBrowser.scss
@@ -49,7 +49,7 @@
   border-radius: 0 4px 4px 0;
   font-size: 12px;
   font-weight: 500;
-  line-height: 38px;
+  line-height: 37px;
   color: #2A98CB !important;
   background-color: #ffffff;
   z-index: 201;


### PR DESCRIPTION
Relates to this story: https://app.shortcut.com/replicated/story/57870/audit-log-search-filter-span-hides-input-field-border

This PR is to make it so that the input text (if it's really long) does not get covered by 'Filters', and it also makes sure that 'Filters' does not cover the input border.

Loom:
https://www.loom.com/share/09e0299602a84acea8a1baef9266a220