### PR TITLE
Removed ace editor to reduce bundle size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "accounting": "0.4.1",
-        "ace-builds": "1.14.0",
         "dayjs": "1.11.7",
         "graphql-request": "5.1.0",
         "lodash": "4.17.21",
         "prop-types": "15.8.1",
-        "react-ace": "10.1.0",
         "react-autobind": "1.0.6",
         "react-datepicker": "4.8.0",
         "react-markdown": "8.0.4",
@@ -1031,11 +1029,6 @@
     "node_modules/accounting": {
       "version": "0.4.1"
     },
-    "node_modules/ace-builds": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.14.0.tgz",
-      "integrity": "sha512-3q8LvawomApRCt4cC0OzxVjDsZ609lDbm8l0Xl9uqG06dKEq4RT0YXLUyk7J2SxmqIp5YXzZNw767Dr8GKUruw=="
-    },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
       "dev": true,
@@ -1318,10 +1311,6 @@
       "engines": {
         "node": ">=0.3.1"
       }
-    },
-    "node_modules/diff-match-patch": {
-      "version": "1.0.5",
-      "license": "Apache-2.0"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.284",
@@ -1683,14 +1672,6 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
-      "license": "MIT"
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
       "license": "MIT"
     },
     "node_modules/loose-envify": {
@@ -2351,21 +2332,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-ace": {
-      "version": "10.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "ace-builds": "^1.4.14",
-        "diff-match-patch": "^1.0.5",
-        "lodash.get": "^4.4.2",
-        "lodash.isequal": "^4.5.0",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-autobind": {
@@ -3686,11 +3652,6 @@
     "accounting": {
       "version": "0.4.1"
     },
-    "ace-builds": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.14.0.tgz",
-      "integrity": "sha512-3q8LvawomApRCt4cC0OzxVjDsZ609lDbm8l0Xl9uqG06dKEq4RT0YXLUyk7J2SxmqIp5YXzZNw767Dr8GKUruw=="
-    },
     "ansi-styles": {
       "version": "3.2.1",
       "dev": true,
@@ -3846,9 +3807,6 @@
     },
     "diff": {
       "version": "5.1.0"
-    },
-    "diff-match-patch": {
-      "version": "1.0.5"
     },
     "electron-to-chromium": {
       "version": "1.4.284",
@@ -4072,12 +4030,6 @@
     },
     "lodash": {
       "version": "4.17.21"
-    },
-    "lodash.get": {
-      "version": "4.4.2"
-    },
-    "lodash.isequal": {
-      "version": "4.5.0"
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -4405,16 +4357,6 @@
       "version": "18.2.0",
       "requires": {
         "loose-envify": "^1.1.0"
-      }
-    },
-    "react-ace": {
-      "version": "10.1.0",
-      "requires": {
-        "ace-builds": "^1.4.14",
-        "diff-match-patch": "^1.0.5",
-        "lodash.get": "^4.4.2",
-        "lodash.isequal": "^4.5.0",
-        "prop-types": "^15.7.2"
       }
     },
     "react-autobind": {

--- a/package.json
+++ b/package.json
@@ -40,12 +40,10 @@
   },
   "dependencies": {
     "accounting": "0.4.1",
-    "ace-builds": "1.14.0",
     "dayjs": "1.11.7",
     "graphql-request": "5.1.0",
     "lodash": "4.17.21",
     "prop-types": "15.8.1",
-    "react-ace": "10.1.0",
     "react-autobind": "1.0.6",
     "react-datepicker": "4.8.0",
     "react-markdown": "8.0.4",

--- a/src/components/containers/EventsBrowser.tsx
+++ b/src/components/containers/EventsBrowser.tsx
@@ -461,6 +461,7 @@ class EventsBrowser extends React.Component {
             this.closeModal();
           }}
           content={this.state.activeModal.modal}
+          ariaHideApp={false}
         />
       </div>
     ) : null;

--- a/src/components/modals/ModalPortal.jsx
+++ b/src/components/modals/ModalPortal.jsx
@@ -3,7 +3,6 @@ import autoBind from "react-autobind";
 import Modal from "react-modal";
 
 export default class ModalPortal extends React.Component {
-
   constructor() {
     super();
     autoBind(this);
@@ -11,26 +10,28 @@ export default class ModalPortal extends React.Component {
 
   generateClassNames() {
     return {
-        base: "retraced-logs-viewer-app retracedModal " + this.props.name,
-        afterOpen: this.props.name + "_after-open",
-        beforeClose: this.props.name + "_before-close"
-    }
+      base: "retraced-logs-viewer-app retracedModal " + this.props.name,
+      afterOpen: this.props.name + "_after-open",
+      beforeClose: this.props.name + "_before-close",
+    };
   }
 
   render() {
     return (
       <div>
-        <Modal 
-            isOpen={this.props.isOpen} 
-            className={this.generateClassNames()} 
-            contentLabel={this.props.name} 
-            onRequestClose={this.props.closeModal}
-        >   
-            {this.props.content}
-            <button className="icon u-closeIcon" onClick={this.props.closeModal}>Close</button>
+        <Modal
+          isOpen={this.props.isOpen}
+          className={this.generateClassNames()}
+          contentLabel={this.props.name}
+          onRequestClose={this.props.closeModal}
+          ariaHideApp={false}
+        >
+          {this.props.content}
+          <button className="icon u-closeIcon" onClick={this.props.closeModal}>
+            Close
+          </button>
         </Modal>
       </div>
     );
   }
 }
-

--- a/src/components/modals/RawEventOutputModal.jsx
+++ b/src/components/modals/RawEventOutputModal.jsx
@@ -1,8 +1,5 @@
 import React from "react";
 import autoBind from "react-autobind";
-import AceEditor from "react-ace";
-import "ace-builds/src-noconflict/mode-javascript";
-import "ace-builds/src-noconflict/theme-github";
 
 export default class RawEventOutputModal extends React.Component {
   constructor() {
@@ -20,18 +17,16 @@ export default class RawEventOutputModal extends React.Component {
         <h1 className="u-fontWeight--normal">Audit Event Info</h1>
         <div className="modal-content">
           <div>
-            <AceEditor
-              mode="javascript"
-              theme="github"
-              width="100%"
-              height="300px"
-              readOnly={true}
-              showGutter={false}
-              showPrintMargin={false}
-              editorProps={{ $blockScrolling: true }}
+            <textarea
+              style={{
+                width: "100%",
+                minHeight: "200px",
+                height: "300px",
+                resize: "none",
+              }}
+              readOnly
               value={raw}
-              fontSize={14}
-            />
+            ></textarea>
           </div>
         </div>
       </div>

--- a/src/css/components/views/EventsBrowser.scss
+++ b/src/css/components/views/EventsBrowser.scss
@@ -140,3 +140,6 @@
   }
 }
 
+.ReactModalPortal {
+  z-index: 10000;
+}


### PR DESCRIPTION
Before:
✓ 747 modules transformed.
dist/style.css                  118.68 kB │ gzip:  17.11 kB
dist/retraced-logs-viewer.js  1,737.66 kB │ gzip: 386.72 kB │ map: 5,353.77 kB
dist/retraced-logs-viewer.umd.cjs  1,247.21 kB │ gzip: 341.17 kB │ map: 5,220.41 kB


After:
✓ 715 modules transformed.
dist/style.css                  118.77 kB │ gzip:  17.13 kB
dist/retraced-logs-viewer.js  1,077.81 kB │ gzip: 233.80 kB │ map: 3,697.20 kB
dist/retraced-logs-viewer.umd.cjs  769.05 kB │ gzip: 205.54 kB │ map: 3,606.43 kB
