### PR TITLE
Make initial query match "blank" query

### DIFF
--- a/src/redux/data/events/thunks.js
+++ b/src/redux/data/events/thunks.js
@@ -75,6 +75,12 @@ export function requestEventSearch(query) {
       data = await response.json();
     } catch (err) {
       console.log(err);
+      dispatch(loadingData("eventFetch", false));
+      return null;
+    }
+    if (data.errors) {
+      console.log(data.errors.map((e) => e.message).join("\n"));
+      dispatch(loadingData("eventFetch", false));
       return null;
     }
 


### PR DESCRIPTION
Thank you for contributing to Retraced!

# Please add a summary of your change

Loom summary: https://www.loom.com/share/718e0f660cbd4a88b892e5e7caa13942

# Does your change fix a particular issue?

Fixes:
- The search query filters on the initial search do not match the default query filters on subsequent searches.
- CRUD filters should not show in the search bar
- Main header should be an h1