### PR TITLE
removing sourcePos prop

### DIFF
--- a/src/components/views/EventRow.jsx
+++ b/src/components/views/EventRow.jsx
@@ -64,7 +64,6 @@ export default class EventRow extends React.Component {
                     <div key={idx} className={`flex flex1 content-section`} data-testid="markdown">
                       <ReactMarkdown
                         className="EventItem u-fontWeight--medium u-lineHeight--more"
-                        sourcePos={true}
                         components={this.props.renderers}
                         children={this.getCellValue(item)}
                       />

--- a/src/components/views/MobileEventRow.jsx
+++ b/src/components/views/MobileEventRow.jsx
@@ -22,7 +22,6 @@ export default class MobileEventRow extends React.Component {
                 <div className="u-color--dustyGray u-fontSize--normal u-lineHeight--normal">
                   <ReactMarkdown
                     className="EventItem u-fontWeight--medium u-lineHeight--more u-display--inlineBlock"
-                    sourcePos={true}
                     components={this.props.renderers}
                     children={this.props.event.display.markdown}
                   />


### PR DESCRIPTION
Thank you for contributing to Retraced!

# Please add a summary of your change
Removes sourcePos prop from ReactMarkdown component

