### PR TITLE
chore: Update artifact download action to use version 4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,12 +120,12 @@ jobs:
         run: rm -rf sbom*.* || true
       - name: Download artifact for SPDX Report
         if: github.ref == 'refs/heads/release'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sbom.spdx
       - name: Download artifact for CycloneDx Report
         if: github.ref == 'refs/heads/release'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sbom.cyclonedx
       - name: ORAS Setup


### PR DESCRIPTION
The artifact download action in the GitHub workflow has been updated to use version 4 of the `actions/download-artifact` action. This change ensures compatibility with the latest version of the action and improves the reliability of downloading artifacts for the SPDX and CycloneDx reports.