### PR TITLE
Fix CSV loading state

### DIFF
--- a/src/redux/data/exports/thunks.js
+++ b/src/redux/data/exports/thunks.js
@@ -64,7 +64,7 @@ export function createSavedExport(query, filters, dates, name) {
       payload.exportBody.endTime = dates.endDate;
     }
 
-    dispatch(loadingData("exportCSVLoading", true));
+    dispatch(loadingData("exportCSV", true));
 
     try {
       const exportResponse = await fetch(exportUrl, {
@@ -96,7 +96,7 @@ export function createSavedExport(query, filters, dates, name) {
 
       await downloadFile(renderedResponse);
 
-      dispatch(loadingData("exportCSVLoading", false));
+      dispatch(loadingData("exportCSV", false));
 
       //dispatch(setIsLoading(false));
       //dispatch(addNewSavedExport(result));


### PR DESCRIPTION
# Please add a summary of your change
The CSV loading state is broken. This causes users to click the Export button multiple times which triggers multiple CSV exports. This PR fixes this issue.

# Does your change fix a particular issue?
No
