### PR TITLE
Show loading state when 'Export' clicked

### DIFF
--- a/src/redux/data/exports/thunks.js
+++ b/src/redux/data/exports/thunks.js
@@ -113,6 +113,8 @@ export function renderSavedExport(id) {
     //dispatch(setIsLoading(true));
     //dispatch(setError(null));
 
+    dispatch(loadingData("exportCSV", true));
+
     const state = getState();
     const projectId = state.data.sessionData.session.project_id;
     const jwt = state.data.sessionData.session.token;
@@ -128,6 +130,8 @@ export function renderSavedExport(id) {
     });
 
     await downloadFile(renderedResponse);
+
+    dispatch(loadingData("exportCSV", false));
 
     //dispatch(setIsLoading(false));
     //dispatch(addNewSavedExport(result));


### PR DESCRIPTION
# Please add a summary of your change

Currently, when the user creates a new saved export, the CSV loading state is triggered. But when they choose an existing saved export, the loading state is not triggered. For large exports that take several seconds, this causes users to click the Export button multiple times which then triggers multiple large exports.

# Does your change fix a particular issue?

No
